### PR TITLE
Add the HARDWARE_PLATFORM external config for gprbuild

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -89,6 +89,8 @@ MAKE_ARGS += -XXMLADA_BUILD=relocatable -XAWS_BUILD=relocatable
 MAKE_ARGS += -XLIBRARY_TYPE=relocatable
 endif
 
+MAKE_ARGS += -XHARDWARE_PLATFORM=@HARDWARE_PLATFORM@
+
 # The timeout execution time in second for a test case.
 # The concurrent fifo test takes arround 120 seconds on some ARM but only 4 seconds on an i7.
 # Make this a make configuration variable so that it can be given when launching make.

--- a/configure
+++ b/configure
@@ -651,6 +651,7 @@ EGREP
 GREP
 CPP
 UTIL_ASM_DIR
+HARDWARE_PLATFORM
 UTIL_OS_VERSION
 UTIL_OS_DIR
 NR_CPUS
@@ -3413,6 +3414,13 @@ $as_echo "using $src_os" >&6; }
 UTIL_OS_DIR=$src_os
 UTIL_OS_VERSION=$os_version
 
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking hardware platform" >&5
+$as_echo_n "checking hardware platform... " >&6; }
+HARDWARE_PLATFORM=`uname -i || uname -m || echo "unknown"`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $HARDWARE_PLATFORM" >&5
+$as_echo "$HARDWARE_PLATFORM" >&6; }
 
 
 # Check for gcc intrinsics

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,11 @@ UTIL_OS_VERSION=$os_version
 AC_SUBST(UTIL_OS_DIR)
 AC_SUBST(UTIL_OS_VERSION)
 
+AC_MSG_CHECKING([hardware platform])
+HARDWARE_PLATFORM=`uname -i || uname -m || echo "unknown"`
+AC_MSG_RESULT($HARDWARE_PLATFORM)
+AC_SUBST(HARDWARE_PLATFORM)
+
 # Check for gcc intrinsics
 AM_HAS_INTRINSIC_SYNC_COUNTERS(src_asm='src/asm-intrinsic',src_asm='')
 AC_MSG_CHECKING([specific processor support])


### PR DESCRIPTION
Some versions of the directories.gpr file require this
information. Basically it's all about figuring out whether to
install libraries under 'lib' or 'lib64'.