### PR TITLE
Test base64 decoding edge cases

### DIFF
--- a/regtests/src/util-encoders-tests.adb
+++ b/regtests/src/util-encoders-tests.adb
@@ -86,7 +86,7 @@ package body Util.Encoders.Tests is
                        Test_HMAC_SHA1_Sign'Access);
       Caller.Add_Test (Suite, "Test Util.Encoders.Encode_LEB128",
                        Test_LEB128'Access);
-      Caller.Add_Test (Suite, "Test Util.Encoders.Base64.Encode",
+      Caller.Add_Test (Suite, "Test Util.Encoders.Base64.Encode_LEB128",
                        Test_Base64_LEB128'Access);
       Caller.Add_Test (Suite, "Test Util.Encoders.HMAC.SHA256.Sign_SHA1 (RFC4231 test1)",
                        Test_HMAC_SHA256_RFC4231_T1'Access);

--- a/regtests/src/util-encoders-tests.adb
+++ b/regtests/src/util-encoders-tests.adb
@@ -52,6 +52,8 @@ package body Util.Encoders.Tests is
                        Test_Base64_Encode'Access);
       Caller.Add_Test (Suite, "Test Util.Encoders.Base64.Decode",
                        Test_Base64_Decode'Access);
+      Caller.Add_Test (Suite, "Test Util.Encoders.Base64.Malleability",
+                       Test_Base64_Malleability'Access);
       Caller.Add_Test (Suite, "Test Util.Encoders.Base64.Encode (URL)",
                        Test_Base64_URL_Encode'Access);
       Caller.Add_Test (Suite, "Test Util.Encoders.Base64.Decode (URL)",
@@ -143,6 +145,91 @@ package body Util.Encoders.Tests is
       Assert_Equals (T, "|~~", Util.Encoders.Decode (D, "fH5+"));
       Test_Encoder (T, C, D);
    end Test_Base64_Decode;
+
+   procedure Test_Base64_Malleability (T : in out Test) is
+   begin
+      declare
+         C : constant Util.Encoders.Encoder := Create ("base64");
+      begin
+         Assert_Equals (T, "SGVsbG8=", Util.Encoders.Encode (C, "Hello"));
+         Assert_Equals (T, "SGVsbA==", Util.Encoders.Encode (C, "Hell"));
+      end;
+      declare
+         D : constant Util.Encoders.Decoder := Create ("base64");
+      begin
+         Assert_Equals (T, "Hello", Util.Encoders.Decode (D, "SGVsbG8=")); -- passes ok
+         Assert_Equals (T, "Hello", Util.Encoders.Decode (D, "SGVsbG9=")); -- shall not pass?
+         -- Assert_Equals (T, "Hello", Util.Encoders.Decode (D, "SGVsbG9")); -- fails
+         Assert_Equals (T, "Hell", Util.Encoders.Decode (D, "SGVsbA==")); -- shall not pass?
+         Assert_Equals (T, "Hell", Util.Encoders.Decode (D, "SGVsbA=")); -- passes ok
+         -- Assert_Equals (T, "Hell", Util.Encoders.Decode (D, "SGVsbA===="));
+      end;
+
+      begin
+         declare
+            double_padding : constant Util.Encoders.Decoder := Create ("base64");
+            S : constant String := Util.Encoders.Decode (double_padding, "SGVsbA====");
+         begin
+            Fail (T, "No exception raised for ==== base64 padding, got: " & S);
+        end;
+      exception
+        when Encoding_Error => null;
+      end;
+
+      declare
+         doubtful : constant Util.Encoders.Decoder := Create ("base64");
+      begin
+         Assert_Equals (T, "Hello", Util.Encoders.Decode (doubtful, "SGVsbG9="));
+      end;
+
+      declare
+         doubtful : constant Util.Encoders.Decoder := Create ("base64");
+      begin
+         Assert_Equals (T, "Hello", Util.Encoders.Decode (doubtful, "SGVsbG9"));
+      end;
+
+      declare
+         wrong_right : constant Util.Encoders.Decoder := Create ("base64");
+      begin
+         Assert_Equals (T, "Hello", Util.Encoders.Decode (wrong_right, "SGVsbG9"));
+         -- Assert_Equals (T, "Hello", Util.Encoders.Decode (wrong_right, "SGVsbG8="));
+      end;
+
+      declare
+         right_wrong : constant Util.Encoders.Decoder := Create ("base64");
+      begin
+         Assert_Equals (T, "Hello", Util.Encoders.Decode (right_wrong, "SGVsbG8="));
+         Assert_Equals (T, "Hello", Util.Encoders.Decode (right_wrong, "SGVsbG9"));
+      end;
+
+      declare
+         standalone : constant Util.Encoders.Decoder := Create ("base64");
+      begin
+         Assert_Equals (T, "Hell", Util.Encoders.Decode (standalone, "SGVsbA="));
+      end;
+
+      declare
+         doubtful : constant Util.Encoders.Decoder := Create ("base64");
+      begin
+         Assert_Equals (T, "Hell", Util.Encoders.Decode (doubtful, "SGVsbA"));
+      end;
+
+-- Invalid character '=' ERROR
+--       declare
+--          wrong_right : constant Util.Encoders.Decoder := Create ("base64");
+--       begin
+--          Assert_Equals (T, "Hell", Util.Encoders.Decode (wrong_right, "SGVsbA"));
+--          Assert_Equals (T, "Hell", Util.Encoders.Decode (wrong_right, "SGVsbA="));
+--       end;
+
+-- util-encoders-tests.adb:230: Test failed: expecting 'Hell' value was '[
+--       declare
+--          right_wrong : constant Util.Encoders.Decoder := Create ("base64");
+--       begin
+--          Assert_Equals (T, "Hell", Util.Encoders.Decode (right_wrong, "SGVsbA="));
+--          Assert_Equals (T, "Hell", Util.Encoders.Decode (right_wrong, "SGVsbA"));
+--       end;
+   end Test_Base64_Malleability;
 
    procedure Test_Base64_URL_Encode (T : in out Test) is
       C : constant Util.Encoders.Encoder := Create ("base64url");

--- a/regtests/src/util-encoders-tests.ads
+++ b/regtests/src/util-encoders-tests.ads
@@ -15,6 +15,7 @@ package Util.Encoders.Tests is
    procedure Test_Hex (T : in out Test);
    procedure Test_Base64_Encode (T : in out Test);
    procedure Test_Base64_Decode (T : in out Test);
+   procedure Test_Base64_Malleability (T : in out Test);
    procedure Test_Base64_URL_Encode (T : in out Test);
    procedure Test_Base64_URL_Decode (T : in out Test);
    procedure Test_Base32_Encode (T : in out Test);


### PR DESCRIPTION
I have tried to integrate some Base64 edge cases taken
from the [Base64 Malleability in Practice](https://eprint.iacr.org/2022/361.pdf) article by Panagiotis Chatzigiannis and Konstantinos Chalkias.

As it turns out, the result of the operation depends
on the order of decode operations, which is pretty
surprising and could be dangerous.

I have also noticed that the decoder implementation
does not recover from an exception.

* Most of the tests raising exceptions have been commented out
* Tests that pass but should probably fail use a variable
  named "doubtful".
* Is there any way to use Assert_Exception from AUnit
  in this project?

(I am pretty new to Ada so everything here can be wrong)